### PR TITLE
Rename delay and tween constructor functions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quip "2.0.3"
+(defproject quip "2.0.4"
   :description "A 2D game library based on Quil"
   :url "https://github.com/Kimbsy/quip"
   :license {:name "Eclipse Public License"

--- a/src/quip/delay.clj
+++ b/src/quip/delay.clj
@@ -6,13 +6,16 @@
 ;;;; @TODO: Should delays be flagged for removeal/persistence across
 ;;;; scene transitions?
 
-(defn ->delay
+(defn delay
   "Create a delay which will execute a function in a specified number of
   frames."
   [remaining f & {:keys [tag] :or {tag :none}}]
   {:remaining      remaining
    :on-complete-fn f
    :tag            tag})
+
+;; @NOTE: deprecated name
+(def ->delay delay)
 
 (defn add-delay
   "Add a delay into the current scene."

--- a/src/quip/tween.clj
+++ b/src/quip/tween.clj
@@ -230,7 +230,7 @@
               (easing-fn s-min)))
          steps)))
 
-(defn ->tween
+(defn tween
   "Create a new tween for modifying a field on a sprite over time."
   [field to-value
    & {:keys [from-value
@@ -268,6 +268,9 @@
    :on-repeat-fn      on-repeat-fn
    :completed?        false
    :on-complete-fn    on-complete-fn})
+
+;; @NOTE: deprecated name
+(def ->tween tween)
 
 (defn add-tween
   [{:keys [tweens] :as sprite} tween]


### PR DESCRIPTION
Keep the old ones to remain backwards compatible.