### PR TITLE
Various updates

### DIFF
--- a/example_games/basic-sprite/project.clj
+++ b/example_games/basic-sprite/project.clj
@@ -1,6 +1,6 @@
 (defproject basic-sprite "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot basic-sprite.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/collision-detection/project.clj
+++ b/example_games/collision-detection/project.clj
@@ -1,6 +1,6 @@
 (defproject collision-detection "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot collision-detection.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/delays/project.clj
+++ b/example_games/delays/project.clj
@@ -1,6 +1,6 @@
 (defproject delays "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot delays.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/fabrik/project.clj
+++ b/example_games/fabrik/project.clj
@@ -1,6 +1,6 @@
 (defproject fabrik "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot fabrik.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/mouse-controls/project.clj
+++ b/example_games/mouse-controls/project.clj
@@ -1,6 +1,6 @@
 (defproject mouse-controls "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot mouse-controls.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/shape-warps/project.clj
+++ b/example_games/shape-warps/project.clj
@@ -1,6 +1,6 @@
 (defproject shape-warps "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot shape-warps.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/sounds/project.clj
+++ b/example_games/sounds/project.clj
@@ -1,6 +1,6 @@
 (defproject sounds "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot sounds.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/squidgy-box/project.clj
+++ b/example_games/squidgy-box/project.clj
@@ -1,6 +1,6 @@
 (defproject squidgy-box "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]]
+                 [quip "3.0.1"]]
   :main ^:skip-aot squidgy-box.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/tweens/project.clj
+++ b/example_games/tweens/project.clj
@@ -1,6 +1,6 @@
 (defproject tweens "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "2.0.7"]
+                 [quip "3.0.1"]
                  [criterium "0.4.6"]]
   :main ^:skip-aot tweens.core
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quip "2.0.7"
+(defproject quip "3.0.1"
   :description "A 2D game library based on Quil"
   :url "https://github.com/Kimbsy/quip"
   :license {:name "Eclipse Public License"

--- a/src/quip/sprite.clj
+++ b/src/quip/sprite.clj
@@ -279,12 +279,23 @@
   "Defines a predicate that filters sprites based on their
   sprite-group.
 
+  Takes either a single `:sprite-group` keyword, or a collection of
+  them.
+
   Commonly used alongside `update-sprites-by-pred`:
 
   (qpsprite/update-sprites-by-pred
     state
     (qpsprite/group-pred :asteroids)
+    sprite-update-fn)
+
+  (qpsprite/update-sprites-by-pred
+    state
+    (qpsprite/group-pred [:asteroids :ships])
     sprite-update-fn)"
   [sprite-group]
-  (fn [s]
-    (= sprite-group (:sprite-group s))))
+  (if (coll? sprite-group)
+    (fn [s]
+      ((set sprite-group) (:sprite-group s)))
+    (fn [s]
+      (= sprite-group (:sprite-group s)))))

--- a/src/quip/tween.clj
+++ b/src/quip/tween.clj
@@ -390,3 +390,30 @@
         cleaned-sprites (remove-completed-tweens updated-sprites)]
     (assoc-in state [:scenes current-scene :sprites]
               cleaned-sprites)))
+
+(defn tween-to-color
+  "Add appropriate tweens to a sprite with 3 or 4 length `:color` vector
+  to morph it to a desired colour.
+
+  The optional `opts` argument can contain any of the standard tween
+  options."
+  ([s c]
+   (tween-to-color s c {}))
+  ([{sprite-color :color :as sprite} target-color opts]
+   (let [component-deltas (map - target-color sprite-color)]
+     (first
+      (reduce (fn [[s i] cd]
+                (let [update-fn (fn [c d] (update c i + d))
+                      yoyo-update-fn (fn [c d] (update c i - d))]
+                  [(add-tween
+                    s
+                    (tween
+                     :color
+                     cd
+                     :update-fn (fn [c d] (update c i + d))
+                     (if (:yoyo? opts)
+                       (assoc opts :yoyo-update-fn yoyo-update-fn)
+                       opts)))
+                   (inc i)]))
+              [sprite 0]
+              component-deltas)))))

--- a/src/quip/utils.clj
+++ b/src/quip/utils.clj
@@ -17,12 +17,18 @@
 (def blue [0 0 255])
 
 (defn darken
-  [color]
-  (map #(max 0 (- % 30)) color))
+  "Darken a colour by 30, preserving alpha component if present."
+  [[_r _g _b a :as color]]
+  (if a
+    (assoc (mapv #(max 0 (- % 30)) color) 3 a)
+    (mapv #(max 0 (- % 30)) color)))
 
 (defn lighten
-  [color]
-  (map #(min 255 (+ % 30)) color))
+  "Lighten a colour by 30, preserving alpha component if present."
+  [[_r _g _b a :as color]]
+  (if a
+    (assoc (mapv #(min 255 (+ % 30)) color) 3 a)
+    (mapv #(min 255 (+ % 30)) color)))
 
 (defn hex->rgb
   [hex-string]


### PR DESCRIPTION
- Force `quip.utils/lighten` and `quip.utils/darken` to return vectors
- Add tween util function for changing the `:color` of a game object
- Modify `quip.sprite/group-pred` to optionally ccept a collection of groups
- Major version bump