### PR TITLE
Add a base sprite constructor function

### DIFF
--- a/example_games/basic-sprite/project.clj
+++ b/example_games/basic-sprite/project.clj
@@ -1,6 +1,6 @@
 (defproject basic-sprite "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot basic-sprite.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/collision-detection/project.clj
+++ b/example_games/collision-detection/project.clj
@@ -1,6 +1,6 @@
 (defproject collision-detection "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot collision-detection.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
+++ b/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
@@ -11,18 +11,19 @@
 (defn square
   "A simple sprite"
   [group pos vel size color]
-  {:sprite-group group
-   :pos pos
+  (qpsprite/sprite
+   group
+   pos
    :vel vel
    :w size
    :h size
-   :color color
    :update-fn (fn [{p :pos v :vel :as b}]
                 (assoc b :pos (mapv + p v)))
    :draw-fn (fn [{[x y] :pos c :color w :w h :h}]
               (qpu/fill c)
               (let [offset (/ w 2)]
-                (q/rect (- x offset) (- y offset) w h)))})
+                (q/rect (- x offset) (- y offset) w h)))
+   :extra {:color color}))
 
 (defn sprites
   "The initial list of sprites for this scene"

--- a/example_games/delays/project.clj
+++ b/example_games/delays/project.clj
@@ -1,6 +1,6 @@
 (defproject delays "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot delays.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/fabrik/project.clj
+++ b/example_games/fabrik/project.clj
@@ -1,6 +1,6 @@
 (defproject fabrik "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot fabrik.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/mouse-controls/project.clj
+++ b/example_games/mouse-controls/project.clj
@@ -1,6 +1,6 @@
 (defproject mouse-controls "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot mouse-controls.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/shape-warps/project.clj
+++ b/example_games/shape-warps/project.clj
@@ -1,6 +1,6 @@
 (defproject shape-warps "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot shape-warps.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/sounds/project.clj
+++ b/example_games/sounds/project.clj
@@ -1,6 +1,6 @@
 (defproject sounds "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot sounds.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/squidgy-box/project.clj
+++ b/example_games/squidgy-box/project.clj
@@ -1,6 +1,6 @@
 (defproject squidgy-box "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]]
+                 [quip "4.0.0"]]
   :main ^:skip-aot squidgy-box.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/example_games/tweens/project.clj
+++ b/example_games/tweens/project.clj
@@ -1,6 +1,6 @@
 (defproject tweens "0.1.0"
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [quip "3.0.1"]
+                 [quip "4.0.0"]
                  [criterium "0.4.6"]]
   :main ^:skip-aot tweens.core
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quip "3.0.1"
+(defproject quip "4.0.0"
   :description "A 2D game library based on Quil"
   :url "https://github.com/Kimbsy/quip"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Rejigged the other constructor functions to use the base `sprite` constructor too.

Also updated all the example games to use the new version of quip. Probably should've done this on it's own earlier.