### PR TITLE
Rename `quip.utils` to `quip.util`

### DIFF
--- a/example_games/basic-sprite/src/basic_sprite/scenes/level_01.clj
+++ b/example_games/basic-sprite/src/basic_sprite/scenes/level_01.clj
@@ -1,6 +1,6 @@
 (ns basic-sprite.scenes.level-01
   (:require [quip.sprite :as qpsprite]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def blue [0 153 255])
 

--- a/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
+++ b/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
@@ -2,7 +2,7 @@
   (:require [quil.core :as q]
             [quip.collision :as qpcollision]
             [quip.sprite :as qpsprite]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def grey [44 49 44])
 (def green [154 225 157])

--- a/example_games/delays/src/delays/scenes/level_01.clj
+++ b/example_games/delays/src/delays/scenes/level_01.clj
@@ -3,7 +3,7 @@
             [quip.delay :as qpdelay]
             [quip.sprite :as qpsprite]
             [quip.tween :as qptween]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def blue [0 153 255])
 

--- a/example_games/fabrik/src/fabrik/scenes/level_01.clj
+++ b/example_games/fabrik/src/fabrik/scenes/level_01.clj
@@ -1,7 +1,7 @@
 (ns fabrik.scenes.level-01
   (:require [quil.core :as q]
             [quip.sprite :as qpsprite]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def light-green [133 255 199])
 (def dark-blue [0 43 54])

--- a/example_games/mouse-controls/src/mouse_controls/scenes/level_01.clj
+++ b/example_games/mouse-controls/src/mouse_controls/scenes/level_01.clj
@@ -2,7 +2,7 @@
   (:require [quil.core :as q]
             [quip.sprite :as qpsprite]
             [quip.tween :as qptween]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def grey [57 57 58])
 (def white [192 214 223])

--- a/example_games/shape-warps/src/shape_warps/scenes/level_01.clj
+++ b/example_games/shape-warps/src/shape_warps/scenes/level_01.clj
@@ -2,7 +2,7 @@
   (:require [quil.core :as q]
             [quip.sprite :as qpsprite]
             [quip.tween :as qptween]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def dark-green [48 58 43])
 (def cyan [88 252 236])

--- a/example_games/sounds/src/sounds/scenes/level_01.clj
+++ b/example_games/sounds/src/sounds/scenes/level_01.clj
@@ -2,7 +2,7 @@
   (:require [quil.core :as q]
             [quip.sprite :as qpsprite]
             [quip.sound :as qpsound]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 ;; Nicer than actual white and black
 (def white [245 245 245])

--- a/example_games/squidgy-box/src/squidgy_box/scenes/level_01.clj
+++ b/example_games/squidgy-box/src/squidgy_box/scenes/level_01.clj
@@ -2,7 +2,7 @@
   (:require [quil.core :as q]
             [quip.sprite :as qpsprite]
             [quip.tween :as qptween]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def gunmetal [0 43 54])
 (def jet [60 60 60])

--- a/example_games/tweens/src/tweens/scenes/level_01.clj
+++ b/example_games/tweens/src/tweens/scenes/level_01.clj
@@ -1,7 +1,7 @@
 (ns tweens.scenes.level-01
   (:require [quip.sprite :as qpsprite]
             [quip.tween :as qptween]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (def blue [0 153 255])
 

--- a/src/quip/collision.clj
+++ b/src/quip/collision.clj
@@ -2,7 +2,7 @@
   "Group-based sprite collision tools and sprite collision detection
   predicates."
   (:require [quil.core :as q]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (defn equal-pos?
   "Predicate to check if two sprites have the same position."

--- a/src/quip/core.clj
+++ b/src/quip/core.clj
@@ -5,7 +5,7 @@
             [quil.middleware :as m]
             [quip.input :as qpinput]
             [quip.sound :as qpsound]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (defn default-update
   [state]

--- a/src/quip/sprite.clj
+++ b/src/quip/sprite.clj
@@ -4,7 +4,7 @@
   The basic sprites provided are useful if simple, feel free to
   implement your own."
   (:require [quil.core :as q]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (defn offset-pos
   [[x y] w h]

--- a/src/quip/sprites/button.clj
+++ b/src/quip/sprites/button.clj
@@ -1,6 +1,6 @@
 (ns quip.sprites.button
   (:require [quil.core :as q]
-            [quip.utils :as qpu]
+            [quip.util :as qpu]
             [quip.sprite :as qpsprite]
             [quip.collision :as qpcollision]))
 

--- a/src/quip/util.clj
+++ b/src/quip/util.clj
@@ -1,4 +1,4 @@
-(ns quip.utils
+(ns quip.util
   "Miscellaneous utility functions.
 
   Vector math functions for position/rotation/velocity calculations.

--- a/test/quip/collision_test.clj
+++ b/test/quip/collision_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [quip.collision :as sut]
             [quip.sprite :as qpsprite]
-            [quip.utils :as qpu]))
+            [quip.util :as qpu]))
 
 (defn test-sprite
   [group pos]

--- a/test/quip/util_test.clj
+++ b/test/quip/util_test.clj
@@ -1,6 +1,6 @@
-(ns quip.utils-test
+(ns quip.util-test
   (:require [clojure.test :refer :all]
-            [quip.utils :as sut]))
+            [quip.util :as sut]))
 
 (deftest lines-intersect?
   (testing "simple intersection"


### PR DESCRIPTION
Consistency with our other namespaces which are all singular rather than plural.