### PR TITLE
Cleaner namespace aliasing

### DIFF
--- a/example_games/basic-sprite/src/basic_sprite/scenes/level_01.clj
+++ b/example_games/basic-sprite/src/basic_sprite/scenes/level_01.clj
@@ -1,12 +1,12 @@
 (ns basic-sprite.scenes.level-01
-  (:require [quip.sprite :as qpsprite]
-            [quip.util :as qpu]))
+  (:require [quip.sprite :as sprite]
+            [quip.util :as u]))
 
 (def blue [0 153 255])
 
 (defn captain
   [pos current-animation]
-  (qpsprite/animated-sprite
+  (sprite/animated-sprite
    :captain   ; sprite-group, used for group collision detection
    pos
    240   ; <- width and
@@ -35,14 +35,14 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background blue)
-  (qpsprite/draw-scene-sprites state))
+  (u/background blue)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state))
+      sprite/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
+++ b/example_games/collision-detection/src/collision_detection/scenes/level_01.clj
@@ -1,8 +1,8 @@
 (ns collision-detection.scenes.level-01
   (:require [quil.core :as q]
-            [quip.collision :as qpcollision]
-            [quip.sprite :as qpsprite]
-            [quip.util :as qpu]))
+            [quip.collision :as collision]
+            [quip.sprite :as sprite]
+            [quip.util :as u]))
 
 (def grey [44 49 44])
 (def green [154 225 157])
@@ -11,7 +11,7 @@
 (defn square
   "A simple sprite"
   [group pos vel size color]
-  (qpsprite/sprite
+  (sprite/sprite
    group
    pos
    :vel vel
@@ -20,7 +20,7 @@
    :update-fn (fn [{p :pos v :vel :as b}]
                 (assoc b :pos (mapv + p v)))
    :draw-fn (fn [{[x y] :pos c :color w :w h :h}]
-              (qpu/fill c)
+              (u/fill c)
               (let [offset (/ w 2)]
                 (q/rect (- x offset) (- y offset) w h)))
    :extra {:color color}))
@@ -35,7 +35,7 @@
 (defn colliders
   "Returns the list of colliders for the scene"
   []
-  [(qpcollision/collider
+  [(collision/collider
     :greens  ;; collision group `a`
     :reds    ;; collision group `b`
 
@@ -58,16 +58,16 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background grey)
-  (qpsprite/draw-scene-sprites state))
+  (u/background grey)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state
+      sprite/update-state
       ;; NOTE: you must update collisions for them to work
-      qpcollision/update-state))
+      collision/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/delays/src/delays/scenes/level_01.clj
+++ b/example_games/delays/src/delays/scenes/level_01.clj
@@ -1,20 +1,20 @@
 (ns delays.scenes.level-01
   (:require [quil.core :as q]
-            [quip.delay :as qpdelay]
-            [quip.sprite :as qpsprite]
-            [quip.tween :as qptween]
-            [quip.util :as qpu]))
+            [quip.delay :as delay]
+            [quip.sprite :as sprite]
+            [quip.tween :as tween]
+            [quip.util :as u]))
 
 (def blue [0 153 255])
 
 (def spin-tween
-  (qptween/tween
+  (tween/tween
    :rotation
    360))
 
 (defn captain
   [pos]
-  (qpsprite/animated-sprite
+  (sprite/animated-sprite
    :captain
    pos
    240
@@ -50,40 +50,40 @@
   "Define the delays which exist as the scene begins."
   []
   [;; We can have a simple side-effecting delayed function:
-   (qpdelay/delay 100 print-current-frame)
+   (delay/delay 100 print-current-frame)
 
    ;; We can add new sprites into the scene:
-   (qpdelay/add-sprites-to-scene 200 [(captain [(rand-int (q/width))
-                                                (rand-int (q/height))])])
+   (delay/add-sprites-to-scene 200 [(captain [(rand-int (q/width))
+                                              (rand-int (q/height))])])
 
    ;; We can add tweens to sprites in the scene:
-   (qpdelay/add-tween-to-sprites 300
-                                 spin-tween
-                                 (fn [s]
-                                   (= :captain (:sprite-group s))))
+   (delay/add-tween-to-sprites 300
+                               spin-tween
+                               (fn [s]
+                                 (= :captain (:sprite-group s))))
 
    ;; We can even delay adding new delays to the scene:
-   (qpdelay/delay
-    400
-    (fn [state]
-      (reduce qpdelay/add-delay
-              state
-              ;; add the same delays again!
-              (delays))))])
+   (delay/delay
+     400
+     (fn [state]
+       (reduce delay/add-delay
+               state
+               ;; add the same delays again!
+               (delays))))])
 
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background blue)
-  (qpsprite/draw-scene-sprites state))
+  (u/background blue)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state
-      qptween/update-state
-      qpdelay/update-state))
+      sprite/update-state
+      tween/update-state
+      delay/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/fabrik/src/fabrik/scenes/level_01.clj
+++ b/example_games/fabrik/src/fabrik/scenes/level_01.clj
@@ -1,7 +1,7 @@
 (ns fabrik.scenes.level-01
   (:require [quil.core :as q]
-            [quip.sprite :as qpsprite]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.util :as u]))
 
 (def light-green [133 255 199])
 (def dark-blue [0 43 54])
@@ -25,8 +25,8 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background dark-blue)
-  (qpsprite/draw-scene-sprites state)
+  (u/background dark-blue)
+  (sprite/draw-scene-sprites state)
 
   (let [chain (get-in state [:scenes :level-01 :chain])]
     (q/stroke orange)
@@ -45,7 +45,7 @@
   (->> chain
        (partition 2 1)
        (map (fn [[p1 p2]]
-              (qpu/magnitude (map - p2 p1))))))
+              (u/magnitude (map - p2 p1))))))
 
 (defn tail-to-root
   "Assuming the last (tail) joint of the chain is in place (at the mouse pos),
@@ -58,7 +58,7 @@
   (reduce (fn [acc [pos l i]]
             (let [next-joint (get acc (inc i))
                   direction (map - pos next-joint)
-                  move (map (partial * l) (qpu/unit-vector direction))                  
+                  move (map (partial * l) (u/unit-vector direction))
                   new-pos (mapv + next-joint move)]
               (assoc acc i new-pos)))
           chain
@@ -79,7 +79,7 @@
   (reduce (fn [acc [pos l i]]
             (let [prev-joint (get acc (dec i))
                   direction (map - pos prev-joint)
-                  move (map (partial * l) (qpu/unit-vector direction))                  
+                  move (map (partial * l) (u/unit-vector direction))
                   new-pos (mapv + prev-joint move)]
               (assoc acc i new-pos)))
           chain

--- a/example_games/mouse-controls/src/mouse_controls/scenes/level_01.clj
+++ b/example_games/mouse-controls/src/mouse_controls/scenes/level_01.clj
@@ -1,8 +1,8 @@
 (ns mouse-controls.scenes.level-01
   (:require [quil.core :as q]
-            [quip.sprite :as qpsprite]
-            [quip.tween :as qptween]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.tween :as tween]
+            [quip.util :as u]))
 
 (def grey [57 57 58])
 (def white [192 214 223])
@@ -10,7 +10,7 @@
 
 (defn heart
   [pos]
-  (qpsprite/animated-sprite
+  (sprite/animated-sprite
    :heart   ; sprite-group, used for group collision detection
    pos
    28   ; <- width and
@@ -34,8 +34,8 @@
   [{[sx sy] :selection-start} sprite]
   (let [ex (q/mouse-x)
         ey (q/mouse-y)]
-    (qpu/rects-overlap? (bounding-rect sprite)
-                        [(min sx ex) (min sy ey) (max sx ex) (max sy ey)])))
+    (u/rects-overlap? (bounding-rect sprite)
+                      [(min sx ex) (min sy ey) (max sx ex) (max sy ey)])))
 
 (defn update-selected-sprites
   [{:keys [selecting?] :as state}]
@@ -44,8 +44,8 @@
                (fn [sprites]
                  (map (fn [s]
                         (if (in-selection? state s)
-                          (qpsprite/set-animation s :selected)
-                          (qpsprite/set-animation s :none)))
+                          (sprite/set-animation s :selected)
+                          (sprite/set-animation s :none)))
                       sprites)))
     state))
 
@@ -62,25 +62,25 @@
                  (concat other
                          (map (fn [{[sx sy] :pos :as sprite}]
                                 (-> sprite
-                                    (qptween/add-tween
-                                     (qptween/tween
+                                    (tween/add-tween
+                                     (tween/tween
                                       :pos
                                       (- tx sx)
-                                      :update-fn qptween/tween-x-fn))
-                                    (qptween/add-tween
-                                     (qptween/tween
+                                      :update-fn tween/tween-x-fn))
+                                    (tween/add-tween
+                                     (tween/tween
                                       :pos
                                       (- ty sy)
-                                      :update-fn qptween/tween-y-fn))))
+                                      :update-fn tween/tween-y-fn))))
                               selected))))))
 
 (defn deselect-all
   [state]
-  (qpsprite/update-sprites-by-pred
+  (sprite/update-sprites-by-pred
    state
-   (qpsprite/group-pred :heart)
+   (sprite/group-pred :heart)
    (fn [s]
-     (qpsprite/set-animation s :none))))
+     (sprite/set-animation s :none))))
 
 (defn handle-mouse-pressed
   [state e]
@@ -113,13 +113,13 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [{:keys [selecting? selection-start] :as state}]
-  (qpu/background grey)
-  (qpsprite/draw-scene-sprites state)
+  (u/background grey)
+  (sprite/draw-scene-sprites state)
 
   (if selecting?
     ;; draw the selection box
     (do
-      (qpu/stroke white)
+      (u/stroke white)
       (q/no-fill)
       (let [x (first selection-start)
             y (second selection-start)
@@ -130,7 +130,7 @@
     ;; draw the target area
     (when (some selected? (get-in state [:scenes :level-01 :sprites]))
       (q/no-stroke)
-      (qpu/fill alpha-green)
+      (u/fill alpha-green)
       (q/ellipse (q/mouse-x) (q/mouse-y) 30 30))))
 
 (defn update-level-01
@@ -138,8 +138,8 @@
   [state]
   (-> state
       update-selected-sprites
-      qpsprite/update-state
-      qptween/update-state))
+      sprite/update-state
+      tween/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/shape-warps/src/shape_warps/scenes/level_01.clj
+++ b/example_games/shape-warps/src/shape_warps/scenes/level_01.clj
@@ -1,8 +1,8 @@
 (ns shape-warps.scenes.level-01
   (:require [quil.core :as q]
-            [quip.sprite :as qpsprite]
-            [quip.tween :as qptween]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.tween :as tween]
+            [quip.util :as u]))
 
 (def dark-green [48 58 43])
 (def cyan [88 252 236])
@@ -21,7 +21,7 @@
   [pos radius point-angles]
   (->> point-angles
        (map (fn [angle]
-              (map (partial * radius) (qpu/direction-vector angle))))
+              (map (partial * radius) (u/direction-vector angle))))
        (map (fn [p]
               (map + pos p)))))
 
@@ -29,7 +29,7 @@
   "We have 12 points (regardless of shape), we use as many as required
   to draw the shape, and keep the rest at 360."
   [{:keys [pos radius point-angles]} & {:keys [color] :or {color cyan}}]
-  (qpu/fill color)
+  (u/fill color)
   (q/begin-shape)
   (doseq [[x y] (points pos radius point-angles)]
     (q/vertex x y))
@@ -37,20 +37,20 @@
 
 (defn multigon-tween
   [i a]
-  (qptween/tween
+  (tween/tween
    :point-angles
    a
    :update-fn (fn [point-angles d]
                 (update point-angles i (partial + d)))
    :step-count 50
-   :easing-fn qptween/ease-in-out-cubic))
+   :easing-fn tween/ease-in-out-cubic))
 
 (defn tween-to
   "Add tweens to each point-angle in the multigon based on the angles
   for an `n` sided multigon."
   [multigon n]
   (reduce (fn [m [i a]]
-            (qptween/add-tween m (multigon-tween i a)))
+            (tween/add-tween m (multigon-tween i a)))
           multigon
           (map vector (range) (map - (angles n) (:point-angles multigon)))))
 
@@ -59,9 +59,9 @@
   (let [n (read-string (name (:key e)))
         n (if (< n 3) (+ n 10) n)]
     (prn n)
-    (qpsprite/update-sprites-by-pred
+    (sprite/update-sprites-by-pred
      state
-     (qpsprite/group-pred :multigon)
+     (sprite/group-pred :multigon)
      (fn [m]
        (tween-to m n)))))
 
@@ -83,15 +83,15 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background dark-green)
-  (qpsprite/draw-scene-sprites state))
+  (u/background dark-green)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state
-      qptween/update-state))
+      sprite/update-state
+      tween/update-state))
 
 (defn key-pressed
   [state e]

--- a/example_games/sounds/src/sounds/core.clj
+++ b/example_games/sounds/src/sounds/core.clj
@@ -1,13 +1,13 @@
 (ns sounds.core
   (:gen-class)
   (:require [quip.core :as qp]
-            [quip.sound :as qpsound]
+            [quip.sound :as sound]
             [sounds.scenes.level-01 :as level-01]))
 
 (defn setup
   "The initial state of the game"
   []
-  (qpsound/loop-music "music/music.wav")
+  (sound/loop-music "music/music.wav")
   ;; Empty state
   {})
 

--- a/example_games/sounds/src/sounds/scenes/level_01.clj
+++ b/example_games/sounds/src/sounds/scenes/level_01.clj
@@ -1,8 +1,8 @@
 (ns sounds.scenes.level-01
   (:require [quil.core :as q]
-            [quip.sprite :as qpsprite]
-            [quip.sound :as qpsound]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.sound :as sound]
+            [quip.util :as u]))
 
 ;; Nicer than actual white and black
 (def white [245 245 245])
@@ -14,7 +14,7 @@
   [state e]
   (if (= :m (:key e))
     (do
-      (qpsound/loop-music "music/music.wav")
+      (sound/loop-music "music/music.wav")
       state)
     state))
 
@@ -30,7 +30,7 @@
   [state e]
   (if (= :s (:key e))
     (do
-      (qpsound/play (rand-nth blips))
+      (sound/play (rand-nth blips))
       state)
     state))
 
@@ -43,11 +43,11 @@
 (defn sprites
   "The initial list of sprites for this scene"
   []
-  [(qpsprite/text-sprite
+  [(sprite/text-sprite
     "Press <m> to restart music"
     [(* 0.5 (q/width)) (* 0.4 (q/height))]
     :color white)
-   (qpsprite/text-sprite
+   (sprite/text-sprite
     "Press <s> to play sound effect"
     [(* 0.5 (q/width)) (* 0.6 (q/height))]
     :color white)])
@@ -55,14 +55,14 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background black)
-  (qpsprite/draw-scene-sprites state))
+  (u/background black)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state))
+      sprite/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/squidgy-box/src/squidgy_box/scenes/level_01.clj
+++ b/example_games/squidgy-box/src/squidgy_box/scenes/level_01.clj
@@ -1,8 +1,8 @@
 (ns squidgy-box.scenes.level-01
   (:require [quil.core :as q]
-            [quip.sprite :as qpsprite]
-            [quip.tween :as qptween]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.tween :as tween]
+            [quip.util :as u]))
 
 (def gunmetal [0 43 54])
 (def jet [60 60 60])
@@ -10,8 +10,8 @@
 
 (defn draw-box
   [{[x y] :pos :keys [w h l-offset r-offset u-offset d-offset] :as b}]
-  (qpu/stroke cultured)
-  (qpu/fill jet)
+  (u/stroke cultured)
+  (u/fill jet)
   (q/rect (- x (/ w 2) l-offset)
           (- y (/ h 2) u-offset)
           (+ w l-offset r-offset)
@@ -38,12 +38,12 @@
   (update-in state
              [:scenes :level-01 :sprites]
              (fn [sprites]
-               [(qptween/add-tween
+               [(tween/add-tween
                  (first sprites)
-                 (qptween/tween offset-key 50
-                                :step-count 10
-                                :yoyo? true
-                                :easing-fn qptween/ease-in-out-sine))])))
+                 (tween/tween offset-key 50
+                              :step-count 10
+                              :yoyo? true
+                              :easing-fn tween/ease-in-out-sine))])))
 
 (defn handle-key-pressed
   [state e]
@@ -65,15 +65,15 @@
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background gunmetal)
-  (qpsprite/draw-scene-sprites state))
+  (u/background gunmetal)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state
-      qptween/update-state))
+      sprite/update-state
+      tween/update-state))
 
 (defn init
   "Initialise this scene"

--- a/example_games/tweens/src/tweens/scenes/level_01.clj
+++ b/example_games/tweens/src/tweens/scenes/level_01.clj
@@ -1,30 +1,30 @@
 (ns tweens.scenes.level-01
-  (:require [quip.sprite :as qpsprite]
-            [quip.tween :as qptween]
-            [quip.util :as qpu]))
+  (:require [quip.sprite :as sprite]
+            [quip.tween :as tween]
+            [quip.util :as u]))
 
 (def blue [0 153 255])
 
 (defn captain
   [pos current-animation]
-  (qpsprite/animated-sprite :captain
-                            pos
-                            240    ; <- width and
-                            360    ; <- height of each animation frame
-                            "img/captain.png"
-                            :animations {:none {:frames      1
-                                                :y-offset    0
-                                                :frame-delay 100}
-                                         :idle {:frames      4
-                                                :y-offset    1
-                                                :frame-delay 15}
-                                         :run  {:frames      4
-                                                :y-offset    2
-                                                :frame-delay 8}
-                                         :jump {:frames      7
-                                                :y-offset    3
-                                                :frame-delay 8}}
-                            :current-animation current-animation))
+  (sprite/animated-sprite :captain
+                          pos
+                          240    ; <- width and
+                          360    ; <- height of each animation frame
+                          "img/captain.png"
+                          :animations {:none {:frames      1
+                                              :y-offset    0
+                                              :frame-delay 100}
+                                       :idle {:frames      4
+                                              :y-offset    1
+                                              :frame-delay 15}
+                                       :run  {:frames      4
+                                              :y-offset    2
+                                              :frame-delay 8}
+                                       :jump {:frames      7
+                                              :y-offset    3
+                                              :frame-delay 8}}
+                          :current-animation current-animation))
 
 (defn tween
   "A tween requires a key of the field to modify and a value to modify it by.
@@ -54,24 +54,24 @@
   We can specify `:on-<x>-fn` functions to modify the sprite when it
   `repeat`s, `yoyo`s or `complete`s."
   []
-  (qptween/tween :pos
-                   300
-                   :update-fn (fn [[x y] d]
-                                [(+ x d) y])
-                   :easing-fn qptween/ease-in-out-quart
-                   :repeat-times 3
-                   :on-repeat-fn (fn [s]
-                                   (prn "REPEAT!")
-                                   (qpsprite/set-animation s :run))
-                   :yoyo? true
-                   :yoyo-update-fn (fn [[x y] d]
-                                     [(- x d) y])
-                   :on-yoyo-fn (fn [s]
-                                 (prn "YOYO!")
-                                 (qpsprite/set-animation s :jump))
-                   :on-complete-fn (fn [s]
-                                     (prn "COMPLETE!")
-                                     (qpsprite/set-animation s :idle))))
+  (tween/tween :pos
+               300
+               :update-fn (fn [[x y] d]
+                            [(+ x d) y])
+               :easing-fn tween/ease-in-out-quart
+               :repeat-times 3
+               :on-repeat-fn (fn [s]
+                               (prn "REPEAT!")
+                               (sprite/set-animation s :run))
+               :yoyo? true
+               :yoyo-update-fn (fn [[x y] d]
+                                 [(- x d) y])
+               :on-yoyo-fn (fn [s]
+                             (prn "YOYO!")
+                             (sprite/set-animation s :jump))
+               :on-complete-fn (fn [s]
+                                 (prn "COMPLETE!")
+                                 (sprite/set-animation s :idle))))
 
 (defn random-pos-tween
   "Creates a non-repeating yoyoing tween which chooses a random axis and
@@ -80,42 +80,42 @@
   When it yoyos a new `random-pos-tween` is added to the sprite."
   []
   (let [axis (rand-int 2)]
-    (qptween/tween :pos
-                     (- (rand-int 200) 100)
-                     :update-fn (if (zero? axis)
-                                  (fn [[x y] d]
-                                    [(+ x d) y])
-                                  (fn [[x y] d]
-                                    [x (+ y d)]))
-                     :yoyo? true
-                     :yoyo-update-fn (if (zero? axis)
-                                       (fn [[x y] d]
-                                         [(- x d) y])
-                                       (fn [[x y] d]
-                                         [x (- y d)]))
-                     :on-yoyo-fn (fn [s] (qptween/add-tween s (random-pos-tween))))))
+    (tween/tween :pos
+                 (- (rand-int 200) 100)
+                 :update-fn (if (zero? axis)
+                              (fn [[x y] d]
+                                [(+ x d) y])
+                              (fn [[x y] d]
+                                [x (+ y d)]))
+                 :yoyo? true
+                 :yoyo-update-fn (if (zero? axis)
+                                   (fn [[x y] d]
+                                     [(- x d) y])
+                                   (fn [[x y] d]
+                                     [x (- y d)]))
+                 :on-yoyo-fn (fn [s] (tween/add-tween s (random-pos-tween))))))
 
 (defn sprites
   "The initial list of sprites for this scene"
   []
   (let [tween           (tween)
         captain-sprite  (captain [150 180] :run)
-        tweened-captain (qptween/add-tween captain-sprite tween)]
+        tweened-captain (tween/add-tween captain-sprite tween)]
     [captain-sprite
      tweened-captain]))
 
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
   [state]
-  (qpu/background blue)
-  (qpsprite/draw-scene-sprites state))
+  (u/background blue)
+  (sprite/draw-scene-sprites state))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-state
-      qptween/update-state))
+      sprite/update-state
+      tween/update-state))
 
 (defn init
   "Initialise this scene"

--- a/src/quip/collision.clj
+++ b/src/quip/collision.clj
@@ -2,12 +2,12 @@
   "Group-based sprite collision tools and sprite collision detection
   predicates."
   (:require [quil.core :as q]
-            [quip.util :as qpu]))
+            [quip.util :as u]))
 
 (defn equal-pos?
   "Predicate to check if two sprites have the same position."
   [{pos-a :pos} {pos-b :pos}]
-  (qpu/equal-pos? pos-a pos-b))
+  (u/equal-pos? pos-a pos-b))
 
 (defn w-h-rects-collide?
   "Predicate to check for overlap of the `w` by `h` rects of two sprites
@@ -26,8 +26,8 @@
         by1 (+ by (- (/ bh 2)))
         bx2 (+ bx bw (- (/ bw 2)))
         by2 (+ by bh (- (/ bh 2)))]
-    (qpu/rects-overlap? [ax1 ay1 ax2 ay2]
-                        [bx1 by1 bx2 by2])))
+    (u/rects-overlap? [ax1 ay1 ax2 ay2]
+                      [bx1 by1 bx2 by2])))
 
 (defn pos-in-rect?
   "Predicate to check if the position of sprite `a` is inside the `w` by
@@ -41,7 +41,7 @@
                 (+ by (- (/ bh 2)))
                 (+ bx bw (- (/ bw 2)))
                 (+ by bh (- (/ bh 2)))]]
-    (qpu/pos-in-rect? pos-a rect-b)))
+    (u/pos-in-rect? pos-a rect-b)))
 
 (defn rect-contains-pos?
   "Predicate to check if the position of sprite `b` is inside the `w` by
@@ -57,7 +57,7 @@
   (let [bounding-poly (->> (bounds-fn b)
                            (map (fn [p] (map - p [(/ w 2) (/ h 2)])))
                            (map (fn [p] (map + p pos-b))))]
-    (qpu/pos-in-poly? pos-a bounding-poly)))
+    (u/pos-in-poly? pos-a bounding-poly)))
 
 (defn poly-contains-pos?
   "Predicate to check if the position of sprite `b` is inside the
@@ -76,16 +76,16 @@
         poly-b (->> (bounds-fn-b b)
                     (map (fn [p] (map - p [(/ wb 2) (/ hb 2)])))
                     (map (fn [p] (map + p pos-b))))]
-    (qpu/polys-collide? poly-a poly-b)))
+    (u/polys-collide? poly-a poly-b)))
 
 (defn- maybe-rotate
   "Rotate a non-zero vector by an angle unless this represents an integer number
   of rotations."
   [v rotation]
   (if (or (zero? (mod (or rotation 0) 360))
-          (qpu/zero-vector? v))
+          (u/zero-vector? v))
     v
-    (qpu/rotate-vector v rotation)))
+    (u/rotate-vector v rotation)))
 
 (defn pos-in-rotating-poly?
   "Predicate to check if the position of sprite `a` is inside the
@@ -97,7 +97,7 @@
                            (map (fn [p] (map - p [(/ w 2) (/ h 2)])))
                            (map #(maybe-rotate % rotation))
                            (map (fn [p] (map + p pos-b))))]
-    (qpu/pos-in-poly? pos-a bounding-poly)))
+    (u/pos-in-poly? pos-a bounding-poly)))
 
 (defn rotating-poly-contains-pos?
   "Predicate to check if the position of sprite `b` is inside the
@@ -120,7 +120,7 @@
                     (map (fn [p] (map - p [(/ wb 2) (/ hb 2)])))
                     (map #(maybe-rotate % rotation-b))
                     (map (fn [p] (map + p pos-b))))]
-    (qpu/polys-collide? poly-a poly-b)))
+    (u/polys-collide? poly-a poly-b)))
 
 
 

--- a/src/quip/core.clj
+++ b/src/quip/core.clj
@@ -3,9 +3,9 @@
   functions."
   (:require [quil.core :as q]
             [quil.middleware :as m]
-            [quip.input :as qpinput]
-            [quip.sound :as qpsound]
-            [quip.util :as qpu]))
+            [quip.input :as input]
+            [quip.sound :as sound]
+            [quip.util :as u]))
 
 (defn default-update
   [state]
@@ -16,7 +16,7 @@
   (q/background 0)
   (q/fill 255)
   (q/text-align :left :baseline)
-  (q/text-font (q/create-font qpu/default-font qpu/default-text-size))
+  (q/text-font (q/create-font u/default-font u/default-text-size))
   (q/text (str "No draw-fn found for current scene " (str current-scene)) 200 200))
 
 (defn update-framerate
@@ -50,8 +50,8 @@
 
 (defn draw-fps-counter
   [{:keys [average-fps] :as state}]
-  (let [text-h qpu/default-text-size
-        text-w (/ qpu/default-text-size 2)]
+  (let [text-h u/default-text-size
+        text-w (/ u/default-text-size 2)]
     ;; draw black box
     (q/fill 0)
     (q/rect 0 0 (* text-w 10) (* text-h 1))
@@ -59,7 +59,7 @@
     ;; draw white fps text (rounded to 2dp)
     (q/text-align :left :center)
     (q/fill 255)
-    (q/text-font (q/create-font qpu/default-font text-h))
+    (q/text-font (q/create-font u/default-font text-h))
     (q/text (str "FPS: " (format "%.2f" (float average-fps))) 0 (/ text-h 2))))
 
 (defn draw-state
@@ -91,10 +91,10 @@
    :setup          (constantly {})
    :update         update-wrapper
    :draw           draw-wrapper
-   :key-pressed    qpinput/key-pressed
-   :key-released   qpinput/key-released
-   :mouse-pressed  qpinput/mouse-pressed
-   :mouse-released qpinput/mouse-released
+   :key-pressed    input/key-pressed
+   :key-released   input/key-released
+   :mouse-pressed  input/mouse-pressed
+   :mouse-released input/mouse-released
    :middleware     [m/fun-mode]
    :on-close       default-on-close
    :frame-rate     60})
@@ -146,7 +146,7 @@
         ;; wrap the existing `:on-close` to stop music playing
         (update :on-close (fn [on-close]
                             (fn [state]
-                              (qpsound/stop-music)
+                              (sound/stop-music)
                               (on-close state)))))))
 
 (defn run

--- a/src/quip/delay.clj
+++ b/src/quip/delay.clj
@@ -1,7 +1,7 @@
 (ns quip.delay
   "Frame-based delays for executing arbitrary code, useful for cutscenes
   and complex animations."
-  (:require [quip.tween :as qptween]))
+  (:require [quip.tween :as tween]))
 
 ;;;; @TODO: Should delays be flagged for removeal/persistence across
 ;;;; scene transitions?
@@ -92,5 +92,5 @@
            relevant   (filter sprite-selection-fn sprites)
            irrelevant (remove sprite-selection-fn sprites)]
        (assoc-in state path (concat irrelevant
-                                    (map #(qptween/add-tween % tween)
+                                    (map #(tween/add-tween % tween)
                                          relevant)))))))

--- a/src/quip/sprite.clj
+++ b/src/quip/sprite.clj
@@ -4,7 +4,7 @@
   The basic sprites provided are useful if simple, feel free to
   implement your own."
   (:require [quil.core :as q]
-            [quip.util :as qpu]))
+            [quip.util :as u]))
 
 (defn offset-pos
   [[x y] w h]
@@ -52,8 +52,8 @@
     (q/with-graphics g
       (.clear g)
       (q/image spritesheet (- x-offset) (- y-offset)))
-    (qpu/wrap-trans-rot pos rotation
-                        #(q/image g (- (/ w 2)) (- (/ h 2))))))
+    (u/wrap-trans-rot pos rotation
+                      #(q/image g (- (/ w 2)) (- (/ h 2))))))
 
 (defn set-animation
   [s animation]
@@ -222,7 +222,7 @@
   (let [[x y] pos]
     (apply q/text-align offsets)
     (q/text-font font)
-    (qpu/fill color)
+    (u/fill color)
     (q/text content x y)))
 
 (defn text-sprite
@@ -237,9 +237,9 @@
            extra]
     :or   {offsets      [:center]
            sprite-group :text
-           font         qpu/default-font
-           size         qpu/default-text-size
-           color        qpu/black
+           font         u/default-font
+           size         u/default-text-size
+           color        u/black
            update-fn    identity
            draw-fn      draw-text-sprite
            extra        {}}}]
@@ -329,14 +329,14 @@
 
   Commonly used alongside `update-sprites-by-pred`:
 
-  (qpsprite/update-sprites-by-pred
+  (sprite/update-sprites-by-pred
     state
-    (qpsprite/group-pred :asteroids)
+    (sprite/group-pred :asteroids)
     sprite-update-fn)
 
-  (qpsprite/update-sprites-by-pred
+  (sprite/update-sprites-by-pred
     state
-    (qpsprite/group-pred [:asteroids :ships])
+    (sprite/group-pred [:asteroids :ships])
     sprite-update-fn)"
   [sprite-group]
   (if (coll? sprite-group)

--- a/src/quip/sprites/button.clj
+++ b/src/quip/sprites/button.clj
@@ -1,26 +1,26 @@
 (ns quip.sprites.button
   (:require [quil.core :as q]
-            [quip.util :as qpu]
-            [quip.sprite :as qpsprite]
-            [quip.collision :as qpcollision]))
+            [quip.util :as u]
+            [quip.sprite :as sprite]
+            [quip.collision :as collision]))
 
 (defn draw-button-sprite
   [{:keys [content pos w h offsets color font content-color content-pos held?]}]
   (q/no-stroke)
   (q/text-align :center :center)
   (q/text-font font)
-  (let [[x y]   (qpsprite/offset-pos pos w h)
+  (let [[x y]   (sprite/offset-pos pos w h)
         [cx cy] content-pos]
     (if held?
-      (do (qpu/fill color)
+      (do (u/fill color)
           (q/rect (+ 2 x) (+ 2 y) w h)
-          (qpu/fill content-color)
+          (u/fill content-color)
           (q/text content (+ 2 x cx) (+ 2 y cy)))
-      (do (qpu/fill (qpu/darken color))
+      (do (u/fill (u/darken color))
           (q/rect (+ 2 x) (+ 2 y) w h)
-          (qpu/fill color)
+          (u/fill color)
           (q/rect x y w h)
-          (qpu/fill content-color)
+          (u/fill content-color)
           (q/text content (+ x cx) (+ y cy))))))
 
 (defn button-sprite
@@ -39,15 +39,15 @@
                   :or   {offsets                [:center :center]
                          on-click               identity
                          size                   [200 100]
-                         color                  qpu/grey
-                         font                   qpu/default-font
-                         font-size              qpu/large-text-size
-                         content-color          qpu/black
+                         color                  u/grey
+                         font                   u/default-font
+                         font-size              u/large-text-size
+                         content-color          u/black
                          content-pos            [100 50]
                          held?                  false
                          update-fn              identity
                          draw-fn                draw-button-sprite
-                         collision-detection-fn qpcollision/pos-in-rect?}}]
+                         collision-detection-fn collision/pos-in-rect?}}]
   (let [[w h] size]
     {:sprite-group           :button
      :uuid                   (java.util.UUID/randomUUID)

--- a/test/quip/collision_test.clj
+++ b/test/quip/collision_test.clj
@@ -1,8 +1,8 @@
 (ns quip.collision-test
   (:require [clojure.test :refer :all]
             [quip.collision :as sut]
-            [quip.sprite :as qpsprite]
-            [quip.util :as qpu]))
+            [quip.sprite :as sprite]
+            [quip.util :as u]))
 
 (defn test-sprite
   [group pos]
@@ -326,9 +326,9 @@
             b [2 4]
             c [8 4]
             d [16 2]]
-        (is (qpu/coarse-pos-in-poly? b a))
-        (is (qpu/coarse-pos-in-poly? c a))
-        (is (not (qpu/coarse-pos-in-poly? d a)))))
+        (is (u/coarse-pos-in-poly? b a))
+        (is (u/coarse-pos-in-poly? c a))
+        (is (not (u/coarse-pos-in-poly? d a)))))
 
     (testing "fine collision detection"
       ;; ┌─────────┐
@@ -341,9 +341,9 @@
             b [2 4]
             c [8 4]
             d [16 2]]
-        (is (qpu/fine-pos-in-poly? b a))
-        (is (not (qpu/fine-pos-in-poly? c a)))
-        (is (not (qpu/fine-pos-in-poly? d a))))))
+        (is (u/fine-pos-in-poly? b a))
+        (is (not (u/fine-pos-in-poly? c a)))
+        (is (not (u/fine-pos-in-poly? d a))))))
 
   (testing "pos-in-poly? and poly-contains-pos?"
     (testing "works on rectangles"
@@ -352,7 +352,7 @@
       ;; │   a    │
       ;; │        │ .d
       ;; └───.c───┘
-      (let [a {:pos [4.5 2] :w 9 :h 4 :bounds-fn qpsprite/default-bounding-poly}
+      (let [a {:pos [4.5 2] :w 9 :h 4 :bounds-fn sprite/default-bounding-poly}
             b {:pos [2 1]}
             c {:pos [4 4]}
             d {:pos [11 3]}]
@@ -439,11 +439,11 @@
       ;; │ └─┼──┼─┘ │
       ;; │ d │  │ e │
       ;; └───┘  └───┘
-      (let [a {:pos [5.5 4] :w 7 :h 4 :bounds-fn qpsprite/default-bounding-poly}
-            b {:pos [2 1.5] :w 4 :h 3 :bounds-fn qpsprite/default-bounding-poly}
-            c {:pos [9 1.5] :w 4 :h 3 :bounds-fn qpsprite/default-bounding-poly}
-            d {:pos [2 6.5] :w 4 :h 3 :bounds-fn qpsprite/default-bounding-poly}
-            e {:pos [9 6.5] :w 4 :h 3 :bounds-fn qpsprite/default-bounding-poly}]
+      (let [a {:pos [5.5 4] :w 7 :h 4 :bounds-fn sprite/default-bounding-poly}
+            b {:pos [2 1.5] :w 4 :h 3 :bounds-fn sprite/default-bounding-poly}
+            c {:pos [9 1.5] :w 4 :h 3 :bounds-fn sprite/default-bounding-poly}
+            d {:pos [2 6.5] :w 4 :h 3 :bounds-fn sprite/default-bounding-poly}
+            e {:pos [9 6.5] :w 4 :h 3 :bounds-fn sprite/default-bounding-poly}]
         ;; a collides with every other sprite
         (is (and (sut/polys-collide? a b)
                  (sut/polys-collide? b a)))
@@ -479,9 +479,9 @@
       ;; ├────┴─┼────┘
       ;; │ c    │
       ;; └──────┘
-      (let [a {:pos [3.5 1.5] :w 7 :h 3 :bounds-fn qpsprite/default-bounding-poly}
-            b {:pos [8.5 1.5] :w 7 :h 3 :bounds-fn qpsprite/default-bounding-poly}
-            c {:pos [3.5 3.5] :w 7 :h 3 :bounds-fn qpsprite/default-bounding-poly}]
+      (let [a {:pos [3.5 1.5] :w 7 :h 3 :bounds-fn sprite/default-bounding-poly}
+            b {:pos [8.5 1.5] :w 7 :h 3 :bounds-fn sprite/default-bounding-poly}
+            c {:pos [3.5 3.5] :w 7 :h 3 :bounds-fn sprite/default-bounding-poly}]
         ;; all sprites collide with each other
         (is (and (sut/polys-collide? a b)
                  (sut/polys-collide? b a)))
@@ -496,8 +496,8 @@
       ;; ║ a  b ║
       ;; ║      ║
       ;; ╚══════╝
-      (let [a {:pos [3.5 2] :w 7 :h 4 :bounds-fn qpsprite/default-bounding-poly}
-            b {:pos [3.5 2] :w 7 :h 4 :bounds-fn qpsprite/default-bounding-poly}]
+      (let [a {:pos [3.5 2] :w 7 :h 4 :bounds-fn sprite/default-bounding-poly}
+            b {:pos [3.5 2] :w 7 :h 4 :bounds-fn sprite/default-bounding-poly}]
         (is (and (sut/polys-collide? a b)
                  (sut/polys-collide? b a)))))
 
@@ -508,8 +508,8 @@
       ;; ││  b   ││
       ;; │└──────┘│
       ;; └────────┘
-      (let [a {:pos [4.5 2.5] :w 9 :h 5 :bounds-fn qpsprite/default-bounding-poly}
-            b {:pos [4.5 3] :w 7 :h 2 :bounds-fn qpsprite/default-bounding-poly}]
+      (let [a {:pos [4.5 2.5] :w 9 :h 5 :bounds-fn sprite/default-bounding-poly}
+            b {:pos [4.5 3] :w 7 :h 2 :bounds-fn sprite/default-bounding-poly}]
         (is (and (sut/polys-collide? a b)
                  (sut/polys-collide? b a))))))
 
@@ -563,7 +563,7 @@
                 :rotation  0
                 :w         9
                 :h         3
-                :bounds-fn qpsprite/default-bounding-poly}
+                :bounds-fn sprite/default-bounding-poly}
             a2 (assoc a1 :rotation 90)
             b  {:pos [7 5]}
             c  {:pos [4 8]}
@@ -642,10 +642,10 @@
               :rotation  0
               :w         13
               :h         3
-              :bounds-fn qpsprite/default-bounding-poly}
+              :bounds-fn sprite/default-bounding-poly}
           a2 (assoc a1 :rotation 90)
-          b  {:pos [6.5 2.5] :w 9 :h 5 :bounds-fn qpsprite/default-bounding-poly}
-          c  {:pos [6.5 12.5] :w 9 :h 5 :bounds-fn qpsprite/default-bounding-poly}]
+          b  {:pos [6.5 2.5] :w 9 :h 5 :bounds-fn sprite/default-bounding-poly}
+          c  {:pos [6.5 12.5] :w 9 :h 5 :bounds-fn sprite/default-bounding-poly}]
       (is (and (not (sut/rotating-polys-collide? a1 b))
                (not (sut/rotating-polys-collide? b a1))))
       (is (and (sut/rotating-polys-collide? a2 b)


### PR DESCRIPTION
Moving from `qpfoo` to just `foo`, often ends up saving us quite a few characters of indentation.