### PR TITLE
Improve ability to restart games

### DIFF
--- a/example_games/game-restart/.gitignore
+++ b/example_games/game-restart/.gitignore
@@ -1,0 +1,12 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/example_games/game-restart/README.md
+++ b/example_games/game-restart/README.md
@@ -1,0 +1,19 @@
+# game-restart
+
+A quip game based on the Quil library.
+
+## Running locally
+
+``` bash
+lein run
+```
+
+## Build jar
+
+``` bash
+# Build
+lein uberjar
+
+# Run
+java -jar target/uberjar/game-restart-0.1.0-standalone.jar
+```

--- a/example_games/game-restart/project.clj
+++ b/example_games/game-restart/project.clj
@@ -1,0 +1,6 @@
+(defproject game-restart "0.1.0"
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [quip "4.0.0"]]
+  :main ^:skip-aot game-restart.core
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all}})

--- a/example_games/game-restart/src/game_restart/core.clj
+++ b/example_games/game-restart/src/game_restart/core.clj
@@ -1,0 +1,42 @@
+(ns game-restart.core
+  (:gen-class)
+  (:require [quip.core :as qp]
+            [game-restart.scenes.menu :as menu]
+            [game-restart.scenes.level-01 :as level-01]))
+
+(defn setup
+  "The initial state of the game"
+  []
+  {:high-score 0
+   :current-score 0})
+
+(defn init-scenes
+  "Map of scenes in the game"
+  []
+  {:menu     (menu/init)
+   :level-01 (level-01/init)})
+
+(defn restart
+  "Define how to restart the game, resetting scenes and sprites
+  etc. Make sure you keep hold of any state that needs to persist
+  between playthroughs."
+  [{:keys [current-score] :as state}]
+  (-> state
+      (assoc :scenes (init-scenes))
+      (assoc :current-scene :menu)
+      (assoc :current-score 0)
+      (update :high-score max current-score)))
+
+;; Configure the game
+(def game-restart-game
+  (qp/game {:title          "game-restart"
+            :size           [800 600]
+            :setup          setup
+            :restart-fn     restart
+            :init-scenes-fn init-scenes
+            :current-scene  :menu}))
+
+(defn -main
+  "Run the game"
+  [& args]
+  (qp/start! game-restart-game))

--- a/example_games/game-restart/src/game_restart/scenes/level_01.clj
+++ b/example_games/game-restart/src/game_restart/scenes/level_01.clj
@@ -1,0 +1,45 @@
+(ns game-restart.scenes.level-01
+  (:require [quil.core :as q]
+            [quip.sprite :as sprite]
+            [quip.util :as u]
+            [quip.core :as qp]))
+
+(def light-green [133 255 199])
+
+(defn sprites
+  "The initial list of sprites for this scene"
+  []
+  [(sprite/text-sprite "Current Score: 0"
+                       [(* 0.5 (q/width))
+                        (* 0.7 (q/height))]
+                       :sprite-group :current-score-text)])
+
+(defn draw-level-01!
+  "Called each frame, draws the current scene to the screen"
+  [state]
+  (u/background light-green)
+  (sprite/draw-scene-sprites! state))
+
+(defn update-level-01
+  "Called each frame, update the sprites in the current scene"
+  [{:keys [current-score] :as state}]
+  (-> state
+      sprite/update-state
+      (sprite/update-sprites-by-pred
+       (sprite/group-pred :current-score-text)
+       (fn [s]
+         (assoc s :content (str "Current Score: " current-score))))))
+
+(defn kp
+  [state e]
+  (if (= 10 (:key-code e))
+    (qp/restart state)
+    (update state :current-score inc)))
+
+(defn init
+  "Initialise this scene"
+  []
+  {:sprites (sprites)
+   :draw-fn draw-level-01!
+   :update-fn update-level-01
+   :key-pressed-fns [kp]})

--- a/example_games/game-restart/src/game_restart/scenes/menu.clj
+++ b/example_games/game-restart/src/game_restart/scenes/menu.clj
@@ -1,0 +1,55 @@
+(ns game-restart.scenes.menu
+  (:require [quil.core :as q]
+            [quip.scene :as scene]
+            [quip.sprite :as sprite]
+            [quip.sprites.button :as button]
+            [quip.util :as u]))
+
+(def white [230 230 230])
+(def grey [57 57 58])
+(def dark-green [41 115 115])
+
+(defn on-click-play
+  "Transition from this scene to `:level-01` with a 30 frame fade-out"
+  [state e]
+  (scene/transition state :level-01 :transition-length 30))
+
+(defn sprites
+  "The initial list of sprites for this scene"
+  []
+  [(button/button-sprite "Play"
+                         [(* 0.5 (q/width))
+                          (* 0.5 (q/height))]
+                         :color grey
+                         :content-color white
+                         :on-click on-click-play)
+   (sprite/text-sprite "Highscore: 0"
+                       [(* 0.5 (q/width))
+                        (* 0.7 (q/height))]
+                       :sprite-group :highscore-text
+                       :color u/white)])
+
+(defn draw-menu!
+  "Called each frame, draws the current scene to the screen"
+  [state]
+  (u/background dark-green)
+  (sprite/draw-scene-sprites! state))
+
+(defn update-menu
+  "Called each frame, update the sprites in the current scene"
+  [{:keys [high-score] :as state}]
+  (-> state
+      sprite/update-state
+      (sprite/update-sprites-by-pred
+       (sprite/group-pred :highscore-text)
+       (fn [s]
+         (assoc s :content (str "Highscore: " high-score))))))
+
+(defn init
+  "Initialise this scene"
+  []
+  {:sprites (sprites)
+   :draw-fn draw-menu!
+   :update-fn update-menu
+   :mouse-pressed-fns [button/handle-buttons-pressed]
+   :mouse-released-fns [button/handle-buttons-released]})

--- a/src/quip/core.clj
+++ b/src/quip/core.clj
@@ -124,8 +124,9 @@
 
   Works with an empty `override-opts`, but needs a `:init-scenes-fn`
   and a `:current-scene` to start doing anything useful."
-  [{:keys [init-scenes-fn current-scene]
+  [{:keys [init-scenes-fn restart-fn current-scene]
     :or   {init-scenes-fn (constantly {})
+           restart-fn       identity
            current-scene  :none}
     :as   override-opts}]
   (let [opts (merge default-opts override-opts)]
@@ -139,6 +140,7 @@
                     (q/frame-rate (:frame-rate opts))
                     (let [initial-state-maps
                           [default-initial-state
+                           {:restart-fn restart-fn}
                            ;; invoke the supplied `:setup` function to
                            ;; allow overriding the initial `state` map
                            (setup)]]
@@ -180,3 +182,7 @@
    :mouse-wheel mouse-wheel
    :middleware middleware
    :on-close on-close))
+
+(defn restart
+  [{:keys [restart-fn] :as state}]
+  (restart-fn state))


### PR DESCRIPTION
By supplying a `restart-fn` to the game and inserting it into the state we give ourselves the ability to request a reset form anywhere in our game.

We avoid the previously experienced circular dependencies since we can define our restart function in core (where our scenes are defined) and we can invoke it while in a scene using quip rather than anything in our own namespaces.