### PR TITLE
Make all sprites potentially clickable

### DIFF
--- a/example_games/clickable-sprites/.gitignore
+++ b/example_games/clickable-sprites/.gitignore
@@ -1,0 +1,12 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/example_games/clickable-sprites/README.md
+++ b/example_games/clickable-sprites/README.md
@@ -1,0 +1,19 @@
+# clickable-sprites
+
+A quip game based on the Quil library.
+
+## Running locally
+
+``` bash
+lein run
+```
+
+## Build jar
+
+``` bash
+# Build
+lein uberjar
+
+# Run
+java -jar target/uberjar/delays-0.1.0-standalone.jar
+```

--- a/example_games/clickable-sprites/project.clj
+++ b/example_games/clickable-sprites/project.clj
@@ -1,0 +1,6 @@
+(defproject clickable-sprites "0.1.0"
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [quip "4.0.0"]]
+  :main ^:skip-aot clickable-sprites.core
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all}})

--- a/example_games/clickable-sprites/src/clickable_sprites/core.clj
+++ b/example_games/clickable-sprites/src/clickable_sprites/core.clj
@@ -1,0 +1,29 @@
+(ns clickable-sprites.core
+  (:gen-class)
+  (:require [clickable-sprites.scenes.level-01 :as level-01]
+            [clickable-sprites.scenes.menu :as menu]
+            [quip.core :as qp]))
+
+(defn setup
+  "The initial state of the game"
+  []
+  {})
+
+(defn init-scenes
+  "Map of scenes in the game"
+  []
+  {:menu     (menu/init)
+   :level-01 (level-01/init)})
+
+;; Configure the game
+(def clickable-sprites-game
+  (qp/game {:title          "clickable-sprites"
+            :size           [800 600]
+            :setup          setup
+            :init-scenes-fn init-scenes
+            :current-scene  :menu}))
+
+(defn -main
+  "Run the game"
+  [& args]
+  (qp/start! clickable-sprites-game))

--- a/example_games/clickable-sprites/src/clickable_sprites/scenes/level_01.clj
+++ b/example_games/clickable-sprites/src/clickable_sprites/scenes/level_01.clj
@@ -1,0 +1,77 @@
+(ns clickable-sprites.scenes.level-01
+  (:require [quil.core :as q]
+            [quip.input :as input]
+            [quip.sprite :as sprite]
+            [quip.util :as u]))
+
+(def light-green [133 255 199])
+
+(defn captain
+  [pos current-animation]
+  (sprite/animated-sprite
+   :captain   ; sprite-group, used for group collision detection
+   pos
+   240   ; <- width and
+   360   ; <- height of each animation frame
+   "img/captain.png"   ; spritesheet location in `resources` directory
+   :animations {:none {:frames      1
+                       :y-offset    0
+                       :frame-delay 100}
+                :idle {:frames      4
+                       :y-offset    1
+                       :frame-delay 15}
+                :run  {:frames      4
+                       :y-offset    2
+                       :frame-delay 8}
+                :jump {:frames      7
+                       :y-offset    3
+                       :frame-delay 8}}
+   :current-animation current-animation))
+
+(def animations [:none :idle :run :jump])
+
+(defn sprites
+  "The initial list of sprites for this scene"
+  []
+  [(-> (captain
+        [(* 0.5 (q/width))
+         (* 0.5 (q/height))]
+        :idle)
+       ;; @TODO: would be nice to generify this `draw-bounding-box`
+       ;; function and have it part of the base sprites.
+       (assoc :draw-fn (fn [{:keys [pos w h] :as s}]
+                         (sprite/draw-animated-sprite! s)
+                         (u/stroke u/red)
+                         (q/no-fill)
+                         (let [offsets (sprite/pos-offsets s)
+                               [x y] (map + pos offsets)]
+                           (q/rect x y w h))
+                         (q/no-stroke)))
+       (input/on-click
+        (fn [state {:keys [current-animation] :as captain}]
+          (sprite/update-sprites-by-pred
+           state
+           (sprite/group-pred :captain)
+           (fn [s]
+             (let [anim (rand-nth animations)]
+               (prn "new animation: " anim)
+               (sprite/set-animation s anim)))))))])
+
+(defn draw-level-01
+  "Called each frame, draws the current scene to the screen"
+  [state]
+  (u/background light-green)
+  (sprite/draw-scene-sprites! state))
+
+(defn update-level-01
+  "Called each frame, update the sprites in the current scene"
+  [state]
+  (-> state
+      sprite/update-state))
+
+(defn init
+  "Initialise this scene"
+  []
+  {:sprites (sprites)
+   :draw-fn draw-level-01
+   :update-fn update-level-01})

--- a/example_games/clickable-sprites/src/clickable_sprites/scenes/menu.clj
+++ b/example_games/clickable-sprites/src/clickable_sprites/scenes/menu.clj
@@ -1,0 +1,39 @@
+(ns clickable-sprites.scenes.menu
+  (:require [quil.core :as q]
+            [quip.input :as input]
+            [quip.scene :as scene]
+            [quip.sprite :as sprite]
+            [quip.sprites.button :as button]
+            [quip.util :as u]))
+
+(def white [230 230 230])
+(def grey [57 57 58])
+(def dark-green [41 115 115])
+
+(defn sprites
+  "The initial list of sprites for this scene"
+  []
+  [(-> (button/button-sprite "play" [(* 0.5 (q/width)) (* 0.5 (q/height))])
+       (input/on-click
+        (fn [state button]
+          (-> state
+              (scene/transition :level-01 :transition-length 30)))))])
+
+(defn draw-menu
+  "Called each frame, draws the current scene to the screen"
+  [state]
+  (u/background dark-green)
+  (sprite/draw-scene-sprites! state))
+
+(defn update-menu
+  "Called each frame, update the sprites in the current scene"
+  [state]
+  (-> state
+      sprite/update-state))
+
+(defn init
+  "Initialise this scene"
+  []
+  {:sprites (sprites)
+   :draw-fn draw-menu
+   :update-fn update-menu})

--- a/src/quip/collision.clj
+++ b/src/quip/collision.clj
@@ -1,9 +1,8 @@
 (ns quip.collision
   "Group-based sprite collision tools and sprite collision detection
   predicates."
-  (:require [quil.core :as q]
-            [quip.util :as u]
-            [quip.sprite :as sprite]))
+  (:require [quip.sprite :as sprite]
+            [quip.util :as u]))
 
 (defn equal-pos?
   "Predicate to check if two sprites have the same position."

--- a/src/quip/sound.clj
+++ b/src/quip/sound.clj
@@ -4,10 +4,7 @@
   There's no support for audio in Quil, so we're relying on interop
   with `javax.sound.sampled`."
   (:require [clojure.java.io :as io])
-  (:import javax.sound.sampled.AudioSystem
-           javax.sound.sampled.Clip
-           javax.sound.sampled.DataLine$Info
-           javax.sound.sampled.LineListener))
+  (:import (javax.sound.sampled AudioSystem Clip DataLine$Info LineListener)))
 
 (defonce ^:dynamic *music* (atom nil))
 

--- a/src/quip/sprite.clj
+++ b/src/quip/sprite.clj
@@ -7,7 +7,7 @@
             [quip.util :as u]))
 
 (defn pos-offsets
-  "Determine the x and y offsets for a sprite based on it's `:w`, `:h`
+ "Determine the x and y offsets for a sprite based on it's `:w`, `:h`
   and `:offsets` configuration.
 
   Defaults to `[:center :center]`."
@@ -50,7 +50,7 @@
           update-animation
           update-pos))
 
-(defn draw-image-sprite
+(defn draw-image-sprite!
   [{:keys [pos rotation image] :as sprite}]
   (u/wrap-trans-rot pos rotation
                     #(let [[x y] (pos-offsets sprite)]
@@ -58,7 +58,7 @@
 
 (def memo-graphics (memoize (fn [w h] (q/create-graphics w h))))
 
-(defn draw-animated-sprite
+(defn draw-animated-sprite!
   [{:keys [pos rotation w h spritesheet current-animation animation-frame] :as s}]
   (let [animation (current-animation (:animations s))
         x-offset  (* animation-frame w)
@@ -150,7 +150,7 @@
            extra]
     :or   {rotation  0
            update-fn identity
-           draw-fn   draw-image-sprite
+           draw-fn   draw-image-sprite!
            offsets   [:center]
            extra     {}}}]
   (merge
@@ -160,7 +160,7 @@
     :image     (q/load-image image-file)
     :rotation  rotation
     :update-fn identity
-    :draw-fn   draw-image-sprite
+    :draw-fn   draw-fn
     :points    points
     :bounds-fn (or bounds-fn
                    (if (seq points)
@@ -182,7 +182,7 @@
     :or   {rotation  0
            vel       [0 0]
            update-fn update-pos
-           draw-fn   draw-image-sprite
+           draw-fn   draw-image-sprite!
            offsets   [:center]
            extra     {}}}]
   (merge
@@ -199,7 +199,7 @@
                    (if (seq points)
                      :points
                      default-bounding-poly))
-    :offsets offsets}
+    :offsets   offsets}
    extra))
 
 (defn animated-sprite
@@ -217,7 +217,7 @@
     :or   {rotation          0
            vel               [0 0]
            update-fn         update-animated-sprite
-           draw-fn           draw-animated-sprite
+           draw-fn           draw-animated-sprite!
            animations        {:none {:frames      1
                                      :y-offset    0
                                      :frame-delay 100}}
@@ -239,7 +239,7 @@
                            (if (seq points)
                              :points
                              default-bounding-poly))
-    :offsets offsets
+    :offsets           offsets
     :animations        animations
     :current-animation current-animation
     :delay-count       0

--- a/src/quip/sprites/button.clj
+++ b/src/quip/sprites/button.clj
@@ -1,116 +1,54 @@
 (ns quip.sprites.button
   (:require [quil.core :as q]
-            [quip.util :as u]
             [quip.sprite :as sprite]
-            [quip.collision :as collision]))
+            [quip.util :as u]))
 
-(defn draw-button-sprite
-  [{:keys [content pos w h offsets color font content-color content-pos held?]}]
+(defn draw-button-sprite!
+  [{:keys [content pos w h color font content-color content-pos] :as button}]
   (q/no-stroke)
   (q/text-align :center :center)
   (q/text-font font)
-  (let [[x y]   (sprite/offset-pos pos w h)
+  (let [[x y]   (map + pos (sprite/pos-offsets button))
         [cx cy] content-pos]
-    (if held?
-      (do (u/fill color)
-          (q/rect (+ 2 x) (+ 2 y) w h)
-          (u/fill content-color)
-          (q/text content (+ 2 x cx) (+ 2 y cy)))
-      (do (u/fill (u/darken color))
-          (q/rect (+ 2 x) (+ 2 y) w h)
-          (u/fill color)
-          (q/rect x y w h)
-          (u/fill content-color)
-          (q/text content (+ x cx) (+ y cy))))))
+    (u/fill (u/darken color))
+    (q/rect (+ 2 x) (+ 2 y) w h)
+    (u/fill color)
+    (q/rect x y w h)
+    (u/fill content-color)
+    (q/text content (+ x cx) (+ y cy))))
 
 (defn button-sprite
   [content pos & {:keys [offsets
-                         on-click
                          size
                          color
                          font
                          font-size
                          content-color
                          content-pos
-                         held?
                          update-fn
                          draw-fn
                          collision-detection-fn]
-                  :or   {offsets                [:center :center]
-                         on-click               identity
-                         size                   [200 100]
-                         color                  u/grey
-                         font                   u/default-font
-                         font-size              u/large-text-size
-                         content-color          u/black
-                         content-pos            [100 50]
-                         held?                  false
-                         update-fn              identity
-                         draw-fn                draw-button-sprite
-                         collision-detection-fn collision/pos-in-rect?}}]
+                  :or   {offsets       [:center :center]
+                         size          [200 100]
+                         color         u/grey
+                         font          u/default-font
+                         font-size     u/large-text-size
+                         content-color u/black
+                         content-pos   [100 50]
+                         update-fn     identity
+                         draw-fn       draw-button-sprite!}}]
   (let [[w h] size]
-    {:sprite-group           :button
-     :uuid                   (java.util.UUID/randomUUID)
-     :content                content
-     :pos                    pos
-     :on-click               on-click
-     :w                      w
-     :h                      h
-     :update-fn              update-fn
-     :color                  color
-     :font                   (q/create-font font font-size)
-     :content-color          content-color
-     :content-pos            content-pos
-     :held?                  held?
-     :draw-fn                draw-fn
-     :collision-detection-fn collision-detection-fn}))
-
-(defn update-held
-  "Update the `:held?` attribute of a specific button to indicate it is
-  being pressed."
-  [{:keys [current-scene] :as state} {:keys [uuid] :as b}]
-  (let [sprites       (get-in state [:scenes current-scene :sprites])
-        other-sprites (remove #(= uuid (:uuid %)) sprites)]
-    (assoc-in state [:scenes current-scene :sprites]
-              (conj other-sprites (assoc b :held? true)))))
-
-
-;;; @TODO: is this the best way of doing this? Seems like we're
-;;; potentially duplicating some of the effort of our mouse event
-;;; handler reduction in input.clj?
-
-;;;  Maybe we could register buttons in the state map in our scene
-;;;  init which would construct a mouse event handler for each button
-;;;  that could check the button position and invoke it's on-click?
-
-;;; Need to put some hammock time into this.
-
-(defn handle-buttons-pressed
-  "Determine if any button sprites have been clicked on. If so invoke
-  their `on-click` function and set their `:held?` attribute to
-  `true`."
-  [{:keys [current-scene] :as state} {ex :x ey :y :as e}]
-  (let [sprites (get-in state [:scenes current-scene :sprites])
-        buttons (filter #(= :button (:sprite-group %)) sprites)]
-    (reduce (fn [acc-state {:keys [collision-detection-fn
-                                   on-click]
-                            :as   b}]
-              (if (collision-detection-fn {:pos [ex ey]} b)
-                (-> acc-state
-                    (on-click e)
-                    (update-held b))
-                acc-state))
-            state
-            buttons)))
-
-(defn handle-buttons-released
-  "Set the `:held?` atribute to `false` for all sprites in the :button
-  sprite-group."
-  [{:keys [current-scene] :as state} _]
-  (let [sprites (get-in state [:scenes current-scene :sprites])
-        buttons (filter #(= :button (:sprite-group %)) sprites)
-        other-sprites (remove #(= :button (:sprite-group %)) sprites)]
-    (assoc-in state [:scenes current-scene :sprites]
-              (concat other-sprites
-                      (map #(assoc % :held? false)
-                           buttons)))))
+    {:sprite-group  :button
+     :uuid          (java.util.UUID/randomUUID)
+     :content       content
+     :pos           pos
+     :w             w
+     :h             h
+     :update-fn     update-fn
+     :color         color
+     :font          (q/create-font font font-size)
+     :content-color content-color
+     :content-pos   content-pos
+     :draw-fn       draw-fn
+     :bounds-fn     sprite/default-bounding-poly
+     :offsets       offsets}))

--- a/src/quip/util.clj
+++ b/src/quip/util.clj
@@ -6,9 +6,9 @@
   Geometric collision detection predicates.
 
   Misc utilities."
-  (:require [quil.core :as q]
-            [clojure.math.combinatorics :as combo]
-            [clojure.set :as s]))
+  (:require [clojure.math.combinatorics :as combo]
+            [clojure.set :as s]
+            [quil.core :as q]))
 
 (def black [0])
 (def white [255])


### PR DESCRIPTION
Moved away form the previous button-focused click handling to something more generic.

Now we can essentially register an on-click function for any sprite, and the new default mouse-pressed handler will apply any on-click-fn of a sprite that collides with the position of the mouse event.