### PR TITLE
Making sure leiningen is available in CI jobs

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -21,6 +21,11 @@ jobs:
         distribution: 'adopt'
         java-version: '17'
 
+    - name: Install Leiningen
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y leiningen
+
     - name: Install dependencies
       run: lein deps
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,6 +16,11 @@ jobs:
         distribution: 'adopt'
         java-version: '17'
 
+    - name: Install Leiningen
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y leiningen
+
     - name: Install dependencies
       run: lein deps
 

--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -18,6 +18,11 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
+      - name: Install Leiningen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y leiningen
+
       - name: Check for outdated dependencies
         run: lein ancient
 


### PR DESCRIPTION
it's no longer available by default on the runners